### PR TITLE
Fix: PaymentSession 생성자 중복 정의 오류 해결 #115

### DIFF
--- a/pay-service/src/main/java/com/example/pay_service/domain/PaymentSession.java
+++ b/pay-service/src/main/java/com/example/pay_service/domain/PaymentSession.java
@@ -5,7 +5,6 @@ import lombok.*;
 import org.hibernate.annotations.Check;
 import org.hibernate.annotations.CreationTimestamp;
 
-import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -57,24 +56,6 @@ public class PaymentSession {
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
-
-    @Builder
-    public PaymentSession(String id, UUID groupId, UUID payerUserId, Long amount,
-                          String recipientBankCode, String recipientAccountNumber,
-                          String recipientName, String recipientBankName,
-                          LocalDateTime expiresAt, Boolean isUsed, LocalDateTime createdAt) {
-        this.id = id;
-        this.groupId = groupId;
-        this.payerUserId = payerUserId;
-        this.amount = amount;
-        this.recipientBankCode = recipientBankCode;
-        this.recipientAccountNumber = recipientAccountNumber;
-        this.recipientName = recipientName;
-        this.recipientBankName = recipientBankName;
-        this.expiresAt = expiresAt;
-        this.isUsed = isUsed != null ? isUsed : false;
-        this.createdAt = createdAt;
-    }
 
     public static PaymentSession create(String id, UUID groupId, UUID payerUserId, Long amount,
                                         String recipientBankCode, String recipientAccountNumber,


### PR DESCRIPTION
## #️⃣ Issue Number

#115

## 📝 요약(Summary)

PaymentSession 클래스에서 @AllArgsConstructor와 수동으로 정의된 생성자가 중복되어 발생하는 컴파일 오류를 해결했습니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

