### PR TITLE
Fix: 초대 코드 생성 시 중복 체크된 코드가 무시되는 버그 수정 #153

### DIFF
--- a/user-service/src/main/java/com/example/user_service/domain/InvitationCode.java
+++ b/user-service/src/main/java/com/example/user_service/domain/InvitationCode.java
@@ -39,9 +39,9 @@ public class InvitationCode {
         }
     }
 
-    public static InvitationCode issue(UUID groupId) {
+    public static InvitationCode issue(UUID groupId, String code) {
         InvitationCode invitationCode = new InvitationCode();
-        invitationCode.code = generateCode();
+        invitationCode.code = code;
         invitationCode.groupId = groupId;
         invitationCode.isExpired = false;
         return invitationCode;

--- a/user-service/src/main/java/com/example/user_service/service/GroupService.java
+++ b/user-service/src/main/java/com/example/user_service/service/GroupService.java
@@ -119,7 +119,7 @@ public class GroupService {
             }
         } while (invitationCodeRepository.existsByCode(code));
 
-        InvitationCode invitation = InvitationCode.issue(groupId);
+        InvitationCode invitation = InvitationCode.issue(groupId, code);
         InvitationCode saved = invitationCodeRepository.save(invitation);
         return saved.getCode();
     }
@@ -141,10 +141,10 @@ public class GroupService {
         GroupMemberId groupMemberId = new GroupMemberId(userId, invitationCode.getGroupId());
         boolean isAlreadyMember = groupMemberRepository.existsById(groupMemberId);
         if (!isAlreadyMember) {
-            groupMemberRepository.save(GroupMember.join(invitationCode.getGroupId(), userId));
-
             group.addMember();
             groupRepository.save(group);
+
+            groupMemberRepository.save(GroupMember.join(invitationCode.getGroupId(), userId));
         }
 
         if (group.isFull()) {


### PR DESCRIPTION
## #️⃣ Issue Number

#153 

## 📝 요약(Summary)

GroupService.issueInvitation 메서드에서 중복 확인 후 생성된 초대 코드가 실제로 사용되지 않는 버그를 수정합니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
