### PR TITLE
Fix: 예수금 충전 투표 가결 시 그룹원들의 예수금 충전하는 로직 구현, 히스토리에 그룹원들의 예수금 잔액을 합산해서 pa…

### DIFF
--- a/trading-service/src/main/java/com/example/trading_service/client/UserServiceClient.java
+++ b/trading-service/src/main/java/com/example/trading_service/client/UserServiceClient.java
@@ -1,0 +1,26 @@
+package com.example.trading_service.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * User Service Client
+ * - trading-service에서 user-service의 internal API 호출용
+ */
+@FeignClient(
+    name = "user-service",
+    url = "${app.services.user-service.url:http://localhost:8082}"
+)
+public interface UserServiceClient {
+    
+    /**
+     * 그룹 멤버 목록 조회
+     * - 그룹에 속한 모든 멤버의 ID 목록
+     */
+    @GetMapping("/internal/groups/{groupId}/members")
+    List<UUID> getGroupMembers(@PathVariable UUID groupId);
+}

--- a/trading-service/src/main/java/com/example/trading_service/config/SecurityConfig.java
+++ b/trading-service/src/main/java/com/example/trading_service/config/SecurityConfig.java
@@ -37,6 +37,9 @@ public class SecurityConfig {
                 // 주식 조회는 인증 불필요
                 .requestMatchers("/api/trading/stocks", "/api/trading/stocks/**").permitAll()
                 .requestMatchers("/trading/stocks", "/trading/stocks/**").permitAll()
+                // Internal API는 서비스 간 통신용으로 허용
+                .requestMatchers("/trading/internal/**").permitAll()
+                .requestMatchers("/api/trading/internal/**").permitAll()
                 // WebSocket API는 인증 불필요
                 .requestMatchers("/api/websocket/**").permitAll()
                 // RewritePath로 변환된 경로들도 허용

--- a/trading-service/src/main/java/com/example/trading_service/controller/TradingController.java
+++ b/trading-service/src/main/java/com/example/trading_service/controller/TradingController.java
@@ -3,6 +3,8 @@ package com.example.trading_service.controller;
 import com.example.trading_service.service.*;
 import com.example.trading_service.dto.*;
 import com.example.trading_service.exception.BusinessException;
+import com.example.module_common.dto.vote.VoteTradingRequest;
+import com.example.module_common.dto.vote.VoteTradingResponse;
 import com.example.trading_service.util.AccountNumberGenerator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -80,6 +82,27 @@ public class TradingController {
         UUID userId = getUserIdFromAuthentication(authentication);
         tradingService.depositFunds(userId, request);
         return ResponseEntity.ok(ApiResponse.success("예수금 충전이 완료되었습니다"));
+    }
+
+    // Internal 예수금 충전 (서비스 간 통신용)
+    @PostMapping("/internal/deposit")
+    public ResponseEntity<ApiResponse<String>> internalDepositFunds(@Valid @RequestBody InternalDepositRequest request) {
+        tradingService.internalDepositFunds(request);
+        return ResponseEntity.ok(ApiResponse.success("Internal 예수금 충전이 완료되었습니다"));
+    }
+
+    // Internal 투표 기반 거래 실행 (서비스 간 통신용)
+    @PostMapping("/internal/vote-trading")
+    public ResponseEntity<VoteTradingResponse> executeVoteBasedTrading(@Valid @RequestBody VoteTradingRequest request) {
+        VoteTradingResponse response = tradingService.executeVoteBasedTrading(request);
+        return ResponseEntity.ok(response);
+    }
+
+    // Internal 그룹 예수금 총합 조회 (서비스 간 통신용)
+    @PostMapping("/internal/group-balance")
+    public ResponseEntity<Integer> getGroupTotalBalance(@RequestBody List<UUID> memberIds) {
+        Integer totalBalance = tradingService.getGroupTotalBalance(memberIds);
+        return ResponseEntity.ok(totalBalance);
     }
 
     @Operation(summary = "보유 종목 조회", description = "사용자가 보유한 모든 종목의 실시간 가격 정보를 조회합니다.")

--- a/trading-service/src/main/java/com/example/trading_service/dto/InternalDepositRequest.java
+++ b/trading-service/src/main/java/com/example/trading_service/dto/InternalDepositRequest.java
@@ -1,0 +1,33 @@
+package com.example.trading_service.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Internal Deposit Request DTO
+ * - 서비스 간 통신용 예수금 충전 요청
+ * - vote-service에서 PAY 투표 가결 시 사용
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class InternalDepositRequest {
+    
+    @NotNull(message = "사용자 ID는 필수입니다.")
+    private UUID userId;
+    
+    @NotNull(message = "충전 금액은 필수입니다.")
+    @Min(value = 1, message = "충전 금액은 1원 이상이어야 합니다.")
+    private BigDecimal amount;
+    
+    @NotNull(message = "그룹 ID는 필수입니다.")
+    private UUID groupId;
+    
+    private String description; // "투표 가결에 따른 예수금 충전" 등
+}

--- a/trading-service/src/main/java/com/example/trading_service/security/UserIdAuthFilter.java
+++ b/trading-service/src/main/java/com/example/trading_service/security/UserIdAuthFilter.java
@@ -28,6 +28,8 @@ public class UserIdAuthFilter extends OncePerRequestFilter {
         return path.startsWith("/ws") ||              // WebSocket 연결 (최우선)
                path.startsWith("/trading/stocks") ||  // 주식 조회
                path.startsWith("/api/trading/stocks") || // API 주식 조회
+               path.startsWith("/trading/internal") || // Internal API (서비스 간 통신)
+               path.startsWith("/api/trading/internal") || // Internal API
                path.startsWith("/api/websocket") ||   // WebSocket API
                path.equals("/status") ||              // RewritePath로 변환된 경로
                path.equals("/reconnect") ||

--- a/trading-service/src/main/java/com/example/trading_service/service/TradingService.java
+++ b/trading-service/src/main/java/com/example/trading_service/service/TradingService.java
@@ -2,6 +2,8 @@ package com.example.trading_service.service;
 
 import com.example.module_common.dto.pay.PayRechargeRequest;
 import com.example.module_common.dto.pay.PayRechargeResponse;
+import com.example.module_common.dto.vote.VoteTradingRequest;
+import com.example.module_common.dto.vote.VoteTradingResponse;
 import com.example.trading_service.client.PayServiceClient;
 import com.example.trading_service.domain.*;
 import com.example.trading_service.dto.*;
@@ -90,6 +92,102 @@ public class TradingService {
         log.info("예수금이 충전되었습니다. 사용자: {}, 충전 금액: {}", userId, request.getAmount());
     }
 
+    /**
+     * Internal 예수금 충전 (서비스 간 통신용)
+     * - vote-service에서 PAY 투표 가결 시 자동으로 호출
+     * - 인증 없이 직접 userId로 처리
+     */
+    @Transactional
+    public void internalDepositFunds(InternalDepositRequest request) {
+        UUID userId = request.getUserId();
+        
+        // 투자 계좌 조회 (없으면 생성)
+        InvestmentAccount account;
+        try {
+            account = getInvestmentAccountByUserId(userId);
+        } catch (IllegalArgumentException e) {
+            // 계좌가 없으면 자동 생성
+            log.info("투자 계좌가 없어 자동 생성합니다. 사용자: {}", userId);
+            UUID accountId = createInvestmentAccount(userId);
+            account = getInvestmentAccountByUserId(userId); // 생성 후 다시 조회
+        }
+        
+        // 잔고 업데이트
+        BalanceCache balance = balanceCacheRepository.findByAccountId(account.getInvestmentAccountId())
+                .orElseThrow(() -> new IllegalArgumentException("잔고 정보를 찾을 수 없습니다."));
+        
+        balance.setBalance(balance.getBalance() + request.getAmount().intValue());
+        balanceCacheRepository.save(balance);
+        
+        log.info("Internal 예수금 충전 완료 - 사용자: {}, 그룹: {}, 충전 금액: {}, 설명: {}", 
+                userId, request.getGroupId(), request.getAmount(), request.getDescription());
+    }
+
+    /**
+     * 투표 기반 거래 실행
+     * - TRADE 투표 가결 시 자동으로 거래 실행
+     */
+    @Transactional
+    public VoteTradingResponse executeVoteBasedTrading(VoteTradingRequest request) {
+        try {
+            log.info("투표 기반 거래 실행 시작 - proposalId: {}, groupId: {}, stockId: {}, action: {}, quantity: {}, price: {}", 
+                    request.proposalId(), request.groupId(), request.stockId(), request.tradingAction(), 
+                    request.quantity(), request.price());
+            
+            // TODO: 실제 거래 로직 구현
+            // 현재는 성공 응답만 반환
+            log.info("투표 기반 거래 실행 완료 - proposalId: {}", request.proposalId());
+            
+            return new VoteTradingResponse(true, "투표 기반 거래가 성공적으로 실행되었습니다", 1);
+            
+        } catch (Exception e) {
+            log.error("투표 기반 거래 실행 실패 - proposalId: {}, 오류: {}", request.proposalId(), e.getMessage(), e);
+            return new VoteTradingResponse(false, "투표 기반 거래 실행 실패: " + e.getMessage(), 0);
+        }
+    }
+
+    /**
+     * 그룹 예수금 총합 조회
+     * - 그룹 멤버들의 예수금 잔액 합계
+     */
+    @Transactional(readOnly = true)
+    public Integer getGroupTotalBalance(List<UUID> memberIds) {
+        try {
+            log.info("그룹 예수금 총합 조회 시작 - memberCount: {}", memberIds.size());
+            
+            Integer totalBalance = 0;
+            
+            // 각 멤버의 예수금 잔액 조회 및 합산
+            for (UUID memberId : memberIds) {
+                try {
+                    // 투자 계좌 조회
+                    Optional<InvestmentAccount> accountOpt = investmentAccountRepository.findByUserId(memberId.toString());
+                    if (accountOpt.isPresent()) {
+                        InvestmentAccount account = accountOpt.get();
+                        
+                        // 잔고 캐시 조회
+                        Optional<BalanceCache> balanceOpt = balanceCacheRepository.findByAccountId(account.getInvestmentAccountId());
+                        if (balanceOpt.isPresent()) {
+                            BalanceCache balance = balanceOpt.get();
+                            totalBalance += balance.getBalance();
+                            log.debug("멤버 예수금 잔액 - memberId: {}, balance: {}", memberId, balance.getBalance());
+                        }
+                    }
+                } catch (Exception e) {
+                    log.warn("멤버 예수금 조회 실패 - memberId: {}, 오류: {}", memberId, e.getMessage());
+                    // 개별 멤버 조회 실패는 전체 프로세스를 중단하지 않음
+                }
+            }
+            
+            log.info("그룹 예수금 총합 조회 완료 - memberCount: {}, totalBalance: {}", 
+                    memberIds.size(), totalBalance);
+            return totalBalance;
+            
+        } catch (Exception e) {
+            log.error("그룹 예수금 총합 조회 실패 - memberCount: {}, 오류: {}", memberIds.size(), e.getMessage(), e);
+            return 0; // 실패 시 기본값 반환
+        }
+    }
 
     // 계좌 잔고 조회 (PortfolioCalculationService로 위임)
     @Transactional(readOnly = true)

--- a/trading-service/src/main/resources/application.yml
+++ b/trading-service/src/main/resources/application.yml
@@ -20,6 +20,9 @@ app:
     issuer: ${JWT_ISSUER:togather}
     access-exp-seconds: ${JWT_ACCESS_EXP:1800}
     refresh-exp-days: ${JWT_REFRESH_EXP:7}
+  services:
+    user-service:
+      url: ${USER_SERVICE_URL:http://localhost:8082}
 
 spring:
   config:

--- a/vote-service/src/main/java/com/example/vote_service/client/TradingServiceClient.java
+++ b/vote-service/src/main/java/com/example/vote_service/client/TradingServiceClient.java
@@ -1,19 +1,44 @@
 package com.example.vote_service.client;
 
-
+import com.example.vote_service.dto.InternalDepositRequest;
 import com.example.module_common.dto.vote.VoteTradingRequest;
 import com.example.module_common.dto.vote.VoteTradingResponse;
-import com.example.vote_service.config.FeignConfig;
-
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import java.util.List;
+import java.util.UUID;
 
-@FeignClient(name = "trading-service", url = "${trading-service.url}", configuration = FeignConfig.class)
-
+/**
+ * Trading Service Client
+ * - vote-service에서 trading-service의 internal API 호출용
+ */
+@FeignClient(
+    name = "trading-service",
+    url = "${app.services.trading-service.url:http://localhost:8081}"
+)
 public interface TradingServiceClient {
-
-    @PostMapping("/vote-trading/execute")
+    
+    /**
+     * Internal 예수금 충전
+     * - PAY 투표 가결 시 그룹 멤버들의 예수금 자동 충전
+     */
+    @PostMapping("/trading/internal/deposit")
+    ResponseEntity<String> internalDepositFunds(@RequestBody InternalDepositRequest request);
+    
+    /**
+     * 투표 기반 거래 실행
+     * - TRADE 투표 가결 시 자동 거래 실행
+     */
+    @PostMapping("/trading/internal/vote-trading")
     VoteTradingResponse executeVoteBasedTrading(@RequestBody VoteTradingRequest request);
+    
+    /**
+     * 그룹 예수금 총합 조회
+     * - 그룹 멤버들의 예수금 잔액 합계
+     */
+    @PostMapping("/trading/internal/group-balance")
+    Integer getGroupTotalBalance(@RequestBody List<UUID> memberIds);
 }

--- a/vote-service/src/main/java/com/example/vote_service/config/SecurityConfig.java
+++ b/vote-service/src/main/java/com/example/vote_service/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
         });
         http.authorizeHttpRequests(reg -> {
             reg.requestMatchers("/actuator/**").permitAll();
+            reg.requestMatchers("/api/notification/stream/**").permitAll(); // SSE 알림 스트림 허용
             reg.anyRequest().authenticated();
         });
         http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);

--- a/vote-service/src/main/java/com/example/vote_service/dto/InternalDepositRequest.java
+++ b/vote-service/src/main/java/com/example/vote_service/dto/InternalDepositRequest.java
@@ -1,0 +1,32 @@
+package com.example.vote_service.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * Internal Deposit Request DTO
+ * - trading-service의 internal deposit API 호출용
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class InternalDepositRequest {
+    
+    @NotNull(message = "사용자 ID는 필수입니다.")
+    private UUID userId;
+    
+    @NotNull(message = "충전 금액은 필수입니다.")
+    @Min(value = 1, message = "충전 금액은 1원 이상이어야 합니다.")
+    private BigDecimal amount;
+    
+    @NotNull(message = "그룹 ID는 필수입니다.")
+    private UUID groupId;
+    
+    private String description; // "투표 가결에 따른 예수금 충전" 등
+}

--- a/vote-service/src/main/java/com/example/vote_service/service/ProposalService.java
+++ b/vote-service/src/main/java/com/example/vote_service/service/ProposalService.java
@@ -274,7 +274,7 @@ public class ProposalService {
             durationMinutes = request.durationMinutes();
             log.info("사용자 설정 투표 기간 사용 - groupId: {}, durationMinutes: {}", groupId, durationMinutes);
         } else {
-            durationMinutes = 10;
+            durationMinutes = 1;
             log.info("기본 투표 기간 사용 - groupId: {}, durationMinutes: {}", groupId, durationMinutes);
         }
 

--- a/vote-service/src/main/resources/application.yml
+++ b/vote-service/src/main/resources/application.yml
@@ -20,6 +20,9 @@ app:
     issuer: ${JWT_ISSUER:togather}
     access-exp-seconds: ${JWT_ACCESS_EXP:1800}
     refresh-exp-days: ${JWT_REFRESH_EXP:7}
+  services:
+    trading-service:
+      url: ${TRADING_SERVICE_URL:http://localhost:8081}
 
 spring:
   config:


### PR DESCRIPTION
## #️⃣ Issue Number
#124 

## 📝 요약(Summary)
예수금 충전 투표가 가결되면, 그룹원들의 투자계좌에 예수금이 자동으로 충전되고,
HIstory에 그룹원들에 투자계좌 잔액을 합산해서 accountBalance로 프론트에 요청합니다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
<img width="791" height="296" alt="image" src="https://github.com/user-attachments/assets/8f32e20e-b646-4808-a3bb-c0f8b1668bc8" />

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
